### PR TITLE
Support userId in invalidateResourceData

### DIFF
--- a/src/generated/types.gen.ts
+++ b/src/generated/types.gen.ts
@@ -2225,6 +2225,9 @@ export type InvalidateResourceData = {
      */
     air: string;
   };
+  query?: {
+    userId?: number;
+  }
 };
 
 export type InvalidateResourceResponse = void;


### PR DESCRIPTION
This is a new param available in the end-point that invalidates' the user's properties basically. Now that you can purchase Early Access on the fly, makes sense to have it.